### PR TITLE
Enable ObjectSpace emulation on jRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - "RAILS=4.2.0"
   global:
     - secure: lRYUGVUV94eqrR7C0b0hhvp+W76NkLRAn6jkJGCbRCEojbeb3HlgK1P+nTDeIuiDmXksJOG6VD3ZiZAn9Plznj7I/MFh+ijgvk8eWj9QNxA8riaSEPAu5VYtPA+uaw1olUt196U3qXH+SaXB4sx5wdIUXpd9qxWWWsW11ia0Jzs=
-    - JRUBY_OPTS="-J-Xmx1024m"
+    - JRUBY_OPTS="-J-Xmx1024m -X+O"
 matrix:
   fast_finish: true
   allow_failures:


### PR DESCRIPTION
With this option we can run `memory_spec.rb`, although a memory leak regarding `ActiveAdmin::Resource` appears. Now is there only one failing.

I'm trying to mitigate the leak, but it is very tricky :/
